### PR TITLE
fix(date): #CO-1657 fix delay date timezone

### DIFF
--- a/src/main/resources/public/ts/controllers/home.ts
+++ b/src/main/resources/public/ts/controllers/home.ts
@@ -58,11 +58,11 @@ export const homeController = ng.controller('HomeController', ['$scope', 'Config
 
 
     vm.sendForm = async (): Promise<void> => {
-        let dayValid = checkCallbackDay();
-        let dateValid = checkCallbackDate();
-        let timeValid = checkCallbackTime();
+        let dayValid: boolean = checkCallbackDay();
+        let dateValid: boolean = checkCallbackDate();
+        let timeValid: boolean = checkCallbackTime();
         if (dayValid && dateValid && timeValid) {
-            let response = await callbackService.post(vm.callback);
+            let response = await callbackService.post(vm.callback.toJson());
             if (response.status == 200) {
                 toasts.confirm(idiom.translate('student.send'));
             } else {

--- a/src/main/resources/public/ts/models/Callback.ts
+++ b/src/main/resources/public/ts/models/Callback.ts
@@ -1,3 +1,5 @@
+import {DateUtils} from "../utils/date";
+
 export class Time {
     hour: number;
     minute: number;
@@ -30,7 +32,7 @@ export class Callback {
     toJson(): Object {
         return {
             destination: this.destination,
-            callback_date: this.callback_date,
+            callback_date: DateUtils.format(new Date(this.callback_date.toDateString()), DateUtils.FORMAT["YEAR-MONTH-DAY-HOUR-MIN-SEC-TIMEZONE"]),
             callback_time: this.callback_time,
             userdata: this.userdata,
             informations_complementaires: this.informations_complementaires

--- a/src/main/resources/public/ts/utils/__test__/date.utils.test.ts
+++ b/src/main/resources/public/ts/utils/__test__/date.utils.test.ts
@@ -1,0 +1,10 @@
+import {DateUtils} from "../date";
+
+describe('Date Utils Test', () => {
+
+    test(`Using "'Thu Jul 14 2022 00:00:00 GMT+0200 (heure d’été d’Europe centrale)'" it should returns '2022-07-14T00:00:00Z'`, () => {
+        const dateToTest = new Date('Thu Jul 14 2022');
+        let formatDate = DateUtils.format(dateToTest, DateUtils.FORMAT["YEAR-MONTH-DAY-HOUR-MIN-SEC-TIMEZONE"]);
+        expect(formatDate).toEqual('2022-07-14T00:00:00Z');
+    });
+});

--- a/src/main/resources/public/ts/utils/date.ts
+++ b/src/main/resources/public/ts/utils/date.ts
@@ -4,6 +4,7 @@ import {DurationInputArg1, DurationInputArg2} from 'moment';
 export class DateUtils {
 
     static FORMAT = {
+        'YEAR-MONTH-DAY-HOUR-MIN-SEC-TIMEZONE': 'YYYY-MM-DDTHH:mm:ss[Z]',
         'YEAR-MONTH-DAY-HOUR-MIN-SEC': 'YYYY-MM-DD HH:mm:ss',
         'YEAR-MONTH-DAY': 'YYYY-MM-DD',
         'YEARMONTHDAY': 'YYYYMMDD',
@@ -27,16 +28,6 @@ export class DateUtils {
     }
 
     /**
-     * Get formatted date day based on given format
-     * @param date date
-     * @param day day number. 0 = Sunday, 6 = Saturday
-     * @param format format
-     */
-    static getDayNumberDate(date: any, day: number, format: string) {
-        return moment(date).day(day).format(format);
-    }
-
-    /**
      * Add step to given date.
      * @param date Date to update
      * @param step Step size
@@ -44,99 +35,5 @@ export class DateUtils {
      */
     static add(date: any, step: DurationInputArg1, stepType: DurationInputArg2 = 'd'): Date {
         return moment(date).add(step, stepType).toDate();
-    }
-
-    /**
-     * Set Date to first Time of day (fr format)
-     * @param date Date to set
-     */
-    static setFirstTime(date: any): Date {
-        return moment(date).set({hour: 0, minute: 0, second: 0}).toDate();
-    }
-
-    /**
-     * Set Date to end Time of day (fr format)
-     * @param date Date to set
-     */
-    static setLastTime(date: any): Date {
-        return moment(date).set({hour: 23, minute: 59, second: 59}).toDate();
-    }
-
-    static isValid(date: any, format: string): Boolean {
-        return (moment(date, format, true).isValid());
-    }
-
-    /**
-     * Check if your start and end date is matching with constant date
-     *
-     * (e.g in register view when we compare our current date with the slots)
-     *
-     * @param startDateValue        StartDate value
-     * @param endDateValue          EndDate value
-     * @param startDateToCompare    StartDate to compare
-     * @param endDateToCompare      EndDate to compare
-     * @param dateValueFormat       date value format (optional)
-     * @param dateToCompareFormat   date to compare format (optional)
-     */
-    static isBetween(startDateValue: string, endDateValue: string,
-                     startDateToCompare: string, endDateToCompare: string,
-                     dateValueFormat?: string, dateToCompareFormat?: string): boolean {
-
-        let startDate = DateUtils
-            .format(startDateValue, dateValueFormat ? dateValueFormat : DateUtils.FORMAT["YEAR-MONTH-DAY-HOUR-MIN-SEC"]);
-        let endDate = DateUtils
-            .format(endDateValue, dateValueFormat ? dateValueFormat : DateUtils.FORMAT["YEAR-MONTH-DAY-HOUR-MIN-SEC"]);
-        let comparedStartDate = DateUtils
-            .format(startDateToCompare, dateToCompareFormat ? dateToCompareFormat : DateUtils.FORMAT["YEAR-MONTH-DAY-HOUR-MIN-SEC"]);
-        let comparedEndDate = DateUtils
-            .format(endDateToCompare, dateToCompareFormat ? dateToCompareFormat : DateUtils.FORMAT["YEAR-MONTH-DAY-HOUR-MIN-SEC"]);
-
-        return ((comparedStartDate >= startDate) || (startDate < comparedEndDate))
-            &&
-            ((comparedEndDate <= endDate) || (endDate > comparedStartDate));
-    }
-
-    /**
-     * ⚠ This method format your TIME but your DATE will have your date.now() ⚠
-     * @param time  time value as a string (e.g) "09:00"
-     */
-    static getTimeFormat(time: string): string {
-        return moment().set('HOUR', time.split(":")[0]).set('MINUTE', time.split(":")[1]);
-    }
-
-
-    /**
-     * ⚠ MUST use "Sort" method. Array based of startTime & endTime ⚠
-     * example : Array.sort(compareTime)
-     *
-     * E.G timeArray: [
-     *      {"id": 1, "start": "18:00","end": "20:00"},
-     *      {"id": 2, "start": "19:00","end": "21:00"},
-     *      {"id": 3, "start": "17:00","end": "19:00"}
-     *   ]
-     *
-     * timeArray.sort(compareTime('start', 'end'));
-     *
-     * Will sort in order [3..., 1..., 2...] then :
-     *   timeArray: [
-     *      {"id": 3, "start": "17:00","end": "19:00"},
-     *      {"id": 1, "start": "18:00","end": "20:00"},
-     *      {"id": 2, "start": "19:00","end": "21:00"}
-     *   ]
-     *
-     * @param startTimeKey  key startDate (could be startDate or start_date)
-     * @param endTimeKey    key endDate (could be endDate or end_date)
-     * param 'a' and 'b' are two elements to compare on function sort
-     */
-    static compareTime(startTimeKey: string, endTimeKey: string) {
-        let startTime = startTimeKey;
-        let endTime = endTimeKey;
-        return function (a, b) {
-            if (a[endTime] < b[endTime] || (a[endTime] == b[endTime] && a[startTime] > b[startTime]))
-                return -1;
-            if (a[endTime] > b[endTime] || (a[endTime] == b[endTime] && a[startTime] < b[startTime]))
-                return 1;
-            return 0;
-        }
     }
 }

--- a/src/test/java/fr/openent/homeworkAssistance/models/KiamoFormTest.java
+++ b/src/test/java/fr/openent/homeworkAssistance/models/KiamoFormTest.java
@@ -50,4 +50,44 @@ public class KiamoFormTest {
 
         ctx.assertEquals(new JsonArray(expectedPayload), kiamoForm.homeworkAssistanceToKiamo());
     }
+
+    @Test
+    public void homeworkAssistanceShould_Send_Correct_Payload_With_Another_Format_Date(TestContext ctx) {
+        JsonObject homeworkCallbackForm = new JsonObject(
+                "{" +
+                        "\"destination\":\"06000000\"," +
+                        "\"callback_date\":\"2022-07-14T00:00:00Z\"," +
+                        "\"callback_time\":{" +
+                        "    \"hour\":\"11\"," +
+                        "    \"minute\":15" +
+                        "}," +
+                        "\"userdata\":{" +
+                        "   \"prenom\":\"Miradi\"," +
+                        "   \"nom\":\"BON\"," +
+                        "   \"etablissement\":\"Etablissement Formation 15613\"," +
+                        "   \"classe\":\"6 3\"," +
+                        "   \"matiere\":\"Test\"," +
+                        "   \"service\":251\r\n   " +
+                        "}," +
+                        "\"informations_complementaires\":\"test\"" +
+                        "}");
+        KiamoForm kiamoForm = new KiamoForm(homeworkCallbackForm);
+
+        String expectedPayload = "[" +
+                "{" +
+                "\"destination\": \"06000000\"," +
+                "\"callback_date\": \"2022-07-14T11:15:00+02:00\"," +
+                "\"userdata\": {" +
+                "    \"prenom_eleve\": \"Miradi\"," +
+                "    \"nom_eleve\": \"BON\"," +
+                "    \"etablissement\": \"Etablissement Formation 15613\"," +
+                "    \"classe\": \"6 3\"," +
+                "    \"matiere_aide\": \"Test\"," +
+                "    \"informations_complementaires\": \"test\"" +
+                " }" +
+                " }" +
+                "]";
+
+        ctx.assertEquals(new JsonArray(expectedPayload), kiamoForm.homeworkAssistanceToKiamo());
+    }
 }


### PR DESCRIPTION
## Describe your changes

Correctif sur le décalage de date
Si on a `'Thu Jul 14 2022 00:00:00 GMT+0200 (heure d’été d’Europe centrale)'`, le format qu'on allait envoyé au back serait 
`'2022-07-13T22:00:00.000Z'` alors qu'on voudrait avoir `'2022-07-13T22:00:00.000Z'`

On modifie le format côté client `toJson()` dans laquelle on change la date en `'Thu Jul 14 2022' avec toDateString()` afin d'éviter le décalage (trick dans laquelle on instancie new Date avec  'Thu Jul 14 2022') pour avoir dans la finalité `'2022-07-14T22:00:00.000Z'`

## Checklist tests

- [ ] Tester l'envoie et vérifie le payload via le network comme quoi on envoie bien la date souhaité (sans décalage)

## Issue ticket number and link

https://entsupport.gdapublic.fr/browse/CO-1657

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)